### PR TITLE
Remove the reconciled event, it is not really useful

### DIFF
--- a/pkg/reconciler/sample/samplesource.go
+++ b/pkg/reconciler/sample/samplesource.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/tracker"
@@ -32,12 +31,6 @@ import (
 	"knative.dev/sample-source/pkg/reconciler"
 	"knative.dev/sample-source/pkg/reconciler/sample/resources"
 )
-
-// newReconciledNormal makes a new reconciler event with event type Normal, and
-// reason SampleSourceReconciled.
-func newReconciledNormal(namespace, name string) pkgreconciler.Event {
-	return pkgreconciler.NewEvent(corev1.EventTypeNormal, "SampleSourceReconciled", "SampleSource reconciled: \"%s/%s\"", namespace, name)
-}
 
 // Reconciler reconciles a SampleSource object
 type Reconciler struct {
@@ -86,5 +79,5 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, src *v1alpha1.SampleSour
 		}
 	}
 
-	return newReconciledNormal(src.Namespace, src.Name)
+	return nil
 }


### PR DESCRIPTION
## Proposed Changes

- Do not produce reconciled-normal events always. This causes spam in the api server and results in n*deps for global resyncs, even for no-ops. 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
For SampleSource, the Kubernetes event "AddressableReconciled" is no longer produced for clean runs of the ReconcileKind method.
```

relates to https://github.com/knative/pkg/issues/1520

/cc @mattmoor 