### PR TITLE
Add lease cluster role to the controller and webhook

### DIFF
--- a/config/201-clusterrole.yaml
+++ b/config/201-clusterrole.yaml
@@ -82,6 +82,13 @@ rules:
   - list
   - watch
 
+  # For Leader Election
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
+  verbs: *everything
+
 ---
 # The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources".
 # See https://github.com/knative/eventing/blob/master/config/200-source-observer-clusterrole.yaml.

--- a/config/203-webhook-clusterrole.yaml
+++ b/config/203-webhook-clusterrole.yaml
@@ -113,3 +113,10 @@ rules:
       - "mutatingwebhookconfigurations"
       - "validatingwebhookconfigurations"
     verbs: *everything
+
+  # For Leader Election
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs: *everything


### PR DESCRIPTION
We need at least these roles to wake up our reconcilers.