### PR TITLE
Add release.sh, update deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
 	knative.dev/eventing v0.18.1-0.20201013101330-20784916d379
 	knative.dev/pkg v0.0.0-20201013114130-602db5ee124d
+	knative.dev/test-infra v0.0.0-20201013100530-45e0761df397
 )
 
 replace (

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Documentation about this script and how to use it can be found
+# at https://github.com/knative/test-infra/tree/master/ci
+
+source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/release.sh
+
+export GO111MODULE=on
+
+# Yaml files to generate, and the source config dir for them.
+declare -A COMPONENTS
+COMPONENTS=(
+  ["sample.yaml"]="config"
+)
+readonly COMPONENTS
+
+function build_release() {
+   # Update release labels if this is a tagged release
+  if [[ -n "${TAG}" ]]; then
+    echo "Tagged release, updating release labels to samples.knative.dev/release: \"${TAG}\""
+    LABEL_YAML_CMD=(sed -e "s|samples.knative.dev/release: devel|samples.knative.dev/release: \"${TAG}\"|")
+  else
+    echo "Untagged release, will NOT update release labels"
+    LABEL_YAML_CMD=(cat)
+  fi
+
+  local all_yamls=()
+  for yaml in "${!COMPONENTS[@]}"; do
+    local config="${COMPONENTS[${yaml}]}"
+    echo "Building Knative Sample Source - ${config}"
+    # TODO(chizhg): reenable --strict mode after https://github.com/knative/test-infra/issues/1262 is fixed.
+    ko resolve ${KO_FLAGS} -f ${config}/ | "${LABEL_YAML_CMD[@]}" > ${yaml}
+    all_yamls+=(${yaml})
+  done
+  ARTIFACTS_TO_PUBLISH="${all_yamls[@]}"
+}
+
+main $@

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -20,4 +20,5 @@ package tools
 
 import (
 	_ "knative.dev/pkg/hack"
+	_ "knative.dev/test-infra/scripts"
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -904,6 +904,7 @@ knative.dev/pkg/webhook/resourcesemantics
 knative.dev/pkg/webhook/resourcesemantics/defaulting
 knative.dev/pkg/webhook/resourcesemantics/validation
 # knative.dev/test-infra v0.0.0-20201013100530-45e0761df397
+## explicit
 knative.dev/test-infra/scripts
 # sigs.k8s.io/structured-merge-diff/v3 v3.0.1-0.20200706213357-43c19bbb7fba
 sigs.k8s.io/structured-merge-diff/v3/value


### PR DESCRIPTION
When building an example without ko using sample-source, it'd be
useful to have releases/nightlies of sample source to pin against.