### PR TITLE
Fixing lint error on copyright notice

### DIFF
--- a/pkg/apis/samples/v1alpha1/register_test.go
+++ b/pkg/apis/samples/v1alpha1/register_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

This seems to need a tab rather than spaces to make the linter happy (see https://github.com/knative-sandbox/sample-source/actions/runs/3968202273/jobs/6801064505)

